### PR TITLE
remove /var check

### DIFF
--- a/checks/base-fs
+++ b/checks/base-fs
@@ -1,4 +1,2 @@
 check device data-system with path /
   if space usage > 90% then alert
-check device data-var with path /var
-  if space usage > 90% then alert


### PR DESCRIPTION
reason: We do not control installation/partition anymore. so to avoid
annoying error in syslog we just remove it and let it to the
administrator