### PR TITLE
auth: remove http check

### DIFF
--- a/checks/wazo-auth
+++ b/checks/wazo-auth
@@ -2,11 +2,4 @@ check process wazo-auth with pidfile /run/wazo-auth/wazo-auth.pid
 	group telephony
 	start program = "/bin/systemctl start wazo-auth.service"
 	stop  program = "/bin/systemctl stop wazo-auth.service"
-	if failed
-		port 9497
-		type tcpssl
-		protocol http
-		request "/0.1/backends"
-		timeout 5 seconds
-		then restart
 	if 5 restarts within 5 cycles then timeout


### PR DESCRIPTION
reason: wazo-auth still use PID and do not support https anymore
To use the same mechanism as other service, we just remove this non
standard check