### PR TITLE
remove unused emails monitoring logic

### DIFF
--- a/wazo-monitoring-update
+++ b/wazo-monitoring-update
@@ -44,12 +44,5 @@ if [ -e $monit_file ]; then
 fi
 cp $monit_file.tmpl $monit_file
 
-emails=$(get_full_email_alerts "monit")
-if [ -n "$emails" ]; then
-    for email in $emails; do
-        echo "set alert $email" >> /etc/monit/monitrc
-    done
-fi
-
 # restart service to take changes into account
 systemctl restart monit > /dev/null


### PR DESCRIPTION
why: to get emails we must have "maintenance" enabled in the DB, but
there is no way to change this value since 18.03