### PR TITLE
monit asterisk: increase restart timeout

### DIFF
--- a/checks/asterisk
+++ b/checks/asterisk
@@ -1,5 +1,5 @@
 check process asterisk with pidfile /run/asterisk/asterisk.pid
 	group telephony
-	start program = "/usr/bin/wazo-service restart wazo-nomonit" with timeout 90 seconds
+	start program = "/usr/bin/wazo-service restart wazo-nomonit" with timeout 180 seconds
 	stop program = "/usr/bin/wazo-service stop wazo-nomonit"
 	if 5 restarts within 5 cycles then timeout


### PR DESCRIPTION
Why:

* One large instances, Asterisk can take a long time to start
* If that time exceeds 90 seconds, the SIP port will remain closed
* If Asterisk starts correctly, monit will not reopen the port